### PR TITLE
Use direct URLs

### DIFF
--- a/demo_site/index.html
+++ b/demo_site/index.html
@@ -19,7 +19,7 @@
   $('#autocomplete').autocomplete({
       source: function(request, response) {
           $.ajax({
-              url: 'entities',
+              url: '/entities',
               type: 'POST',
               dataType: 'json',
               data: { search: request.term },


### PR DESCRIPTION
Whenever you use ajax to query something you always want to use direct URLs instead of relative URLs so you don't get errors when querying from a different page other than `/`
